### PR TITLE
Fixed account/add page, Done cancel, confirm button's feature in orderand order/detail page

### DIFF
--- a/src/page/mypage.js
+++ b/src/page/mypage.js
@@ -396,11 +396,11 @@ async function renderAccountListOptionAdd(bankSelectEl, bankAccount, profile){
   ];
 
   const bankListArr = logoList.map( ([bankName, bankImg]) => {
-    const bankSelectOptionEl = document.createElement('div');
+    const bankSelectOptionEl = document.createElement('label');
     bankSelectOptionEl.className = `bankSelectOption`;
     bankSelectOptionEl.innerHTML = /*html*/`
       <input type="radio" id="${bankName}" name="bankList" value="${bankName}">
-      <label for="${bankName}">${bankImg}${bankName}</label>
+      <span>${bankImg}${bankName}</span>
     `;
 
     let currentCheckedBank;

--- a/src/page/mypage.js
+++ b/src/page/mypage.js
@@ -9,7 +9,7 @@ import {
   getCurrentAccount,
   addBankAccount
 } from "../utilities/userapi";
-import { getBuyList, getBuyDetail, getProductDetail } from "../utilities/productapi";
+import { getBuyList, getBuyDetail, getProductDetail, cancelBuy, confirmBuy } from "../utilities/productapi";
 
 export async function renderOrderHisory() {
   const app = document.querySelector("#app");
@@ -55,7 +55,7 @@ export async function renderOrderHisory() {
 }
 
 async function renderBuyList(contentEl, buyList) {
-  const buyItemEl = buyList.map((item) => {
+  const buyItemEl = buyList.map( (item) => {
     const buyItemLiEl = document.createElement("a");
     buyItemLiEl.className = "buyItemLi";
 
@@ -113,6 +113,9 @@ async function renderBuyList(contentEl, buyList) {
       btnsEl.append(isCanceledBtnEl, doneBtnEl);
 
       summaryEl.append(btnsEl);
+
+      cancelDoneBtns(isCanceledBtnEl, doneBtnEl, item.detailId);
+
     } else {
       const repurchaseBtnEl = document.createElement("button");
       repurchaseBtnEl.setAttribute('type', 'button');
@@ -132,6 +135,18 @@ async function renderBuyList(contentEl, buyList) {
     return buyItemLiEl;
   });
   contentEl.append(...buyItemEl);
+}
+
+// 주문취소, 구매확정 버튼 이벤트 함수
+async function cancelDoneBtns(isCanceledBtnEl, doneBtnEl, detailId) {
+  isCanceledBtnEl.addEventListener('click', async () => {
+    await cancelBuy(userToken._token, detailId);
+    location.reload();
+  })
+  doneBtnEl.addEventListener('click', async () => {
+    await confirmBuy(userToken._token, detailId);
+    location.reload();
+  })
 }
 
 export async function renderOrderDetail(detailId) {
@@ -224,6 +239,8 @@ export async function renderOrderDetail(detailId) {
       btnsEl.append(isCanceledBtnEl, doneBtnEl);
 
       productInfoBtns.append(btnsEl);
+
+      cancelDoneBtns(isCanceledBtnEl, doneBtnEl, orderDetail.detailId);
     } else {
       const repurchaseBtnEl = document.createElement("button");
       repurchaseBtnEl.setAttribute('type', 'button');
@@ -245,6 +262,10 @@ export async function renderOrderDetail(detailId) {
         router.navigate(`/product/detail/${productInfoEl.id}`);
       }
     });
+
+    productInfoBtns.addEventListener('click', (event) => {
+      event.stopPropagation();
+    })
 
     const loading = document.querySelector(".skeleton");
     loading.remove();

--- a/src/style/mypage.scss
+++ b/src/style/mypage.scss
@@ -340,38 +340,40 @@ $gap: 10px;
           padding-bottom: $padding;
         }
         .accountAdd__bank__list{
-          display: flex;
-          flex-wrap: wrap;
-          row-gap: $gap;
+          display: grid;
+          grid-template-columns: repeat(6, 150px);
+          justify-content: center;
+          gap: $gap;
           .bankSelectOption{
-            display: flex;
-            align-items: center;
-            [type='radio'] {
-              appearance: none;
-              border: none;
-            }
-            [type='radio']:disabled + label {
-              opacity: 0.3;
-              cursor: not-allowed;
-            }
-            [type='radio']:checked + label {
-              border-color: $dark-gray;
-              background-color: $light-gray;
-            }
-            label {
+            @include flex-center;
+            span {
               @include flex-center;
-              gap: $gap;
+              width: 150px;
+              height: 55px;
               padding: 10px;
-              width: 145px;
-              height: 50px;
+              gap: $gap;
               cursor: pointer;
               border: 4px solid $primary-color;
               border-radius: 5px;
               transition: 0.3s;
             }
-            label:hover {
+            [type='radio'] {
+              appearance: none;
+              border: none;
+              margin: 0px;
+              padding: 0px;
+            }
+            [type='radio']:disabled + span {
+              opacity: 0.3;
+              pointer-events: none;
+            }
+            [type='radio']:checked + span {
               border-color: $dark-gray;
-              background-color: $light-gray;
+              background-color: darken($light-gray, 10%);
+            }
+            span:hover {
+              border-color: $dark-gray;
+              background-color: darken($light-gray, 10%);
             }
           }
         }


### PR DESCRIPTION
## 한 일
- account/add page 내 은행 리스트에서 은행 이름이 줄 바꿈 되지 않고 표시되도록 함.
- 은행 리스트 자체를 가운데 정렬 시키고, 선택 불가 항목의 경우 hover 효과가 나타나지 않도록 수정
- 나의 주문 페이지와 주문 상세 내역 페이지의 주문취소 버튼과 구매 확정 버튼이 동작할 수 있도록 함.
- 해당 버튼 클릭시 api를 호출하여 해당 내용을 수행하고, 어디에서 클릭하든 주문 상세 화면으로 이동하여 그 결과를 확인할 수 있음. 

## 남은 일
- [x] 나의 계좌 삭제 기능 구현
- [x] 주문 내역에서 재구매 버튼 기능 구현
- [x] mypage.js 파일의 함수들을 여러 파일로 분리하여 유지보수와 가독성을 용이하게 할 것.
- [ ] mypage의 성능을 최적화 하여 로딩 시간을 단축할 것.

## 고도화 하고 싶은 사항
- [ ] 사용자에게 한 번 더 확인이 필요한 기능들에 대해 모달 창 적용
- [ ] 주문 내역 페이지에서 주문 내역 리스트를 페이지네이션을 통해 페이지 길이 줄이기
- [ ] 계좌 추가 페이지에서 입력 값에 대해 실시간으로 피드백을 줄 수 있는 구조로 개선

